### PR TITLE
fix usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ To use this theme in NixOS set your SLiM configuration settings like so:
 
 ```
 
-  services.displayManager.slim = {
+  services.xserver.displayManager.slim = {
     enable = true;
     theme = pkgs.fetchurl {
       url = "https://github.com/edwtjo/nixos-black-theme/archive/v1.0.tar.gz";


### PR DESCRIPTION
`services.xserver.displayManager` instead of `services.displayManager` (which does not exist)
